### PR TITLE
[FIX] installation problem (missing path to numpy)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@
 ## to distribute cython modules.
 from distutils.core import setup
 from Cython.Build import cythonize
+import numpy
 
 setup(
     name = "MBSV preprocessing app",
-    ext_modules = cythonize('src/insDelHmm.pyx'),  
+    ext_modules = cythonize('src/insDelHmm.pyx'),
+    include_dirs=[numpy.get_include()],
 )
 


### PR DESCRIPTION
On my server the installation failed due to an unusual location of numpy libraries. This should fix it.
Best, meiers
